### PR TITLE
Add API validation 'layer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,41 @@ npm run start
 ```
 It uses nodemon for livereloading :peace-fingers:
 
+# API Validation
+ 
+ By using celebrate the req.body schema becomes clary defined at route level, so even frontend devs can read what an API endpoint expects without need to writting a documentation that can get outdated quickly.
+
+ ```js
+ route.post('/signup', 
+  celebrate({
+    body: Joi.object({
+      name: Joi.string().required(),
+      email: Joi.string().required(),
+      password: Joi.string().required(),
+    }),
+  }),
+  controller.signup)
+ ```
+
+ **Example error**
+
+ ```json
+ {
+  "errors": {
+    "message": "child \"email\" fails because [\"email\" is required]"
+  }
+ } 
+ ```
+
+[Read more about celebrate here](https://github.com/arb/celebrate) and [the Joi validation API](https://github.com/hapijs/joi/blob/v15.0.1/API.md)
 
 # Roadmap
-- [ ] API Validation layer (Celebrate+Joi)
+- [x] API Validation layer (Celebrate+Joi)
 - [ ] Unit tests examples
 - [ ] [Cluster mode](https://softwareontheroad.com/nodejs-scalability-issues?utm_source=github&utm_medium=readme)
 - [ ] The logging _'layer'_ 
 - [ ] Add ageda dashboard
-- [ ] Continuous integration with CircleCI 😍
+- [x] Continuous integration with CircleCI 😍
 - [ ] Deploys script and docs for AWS Elastic Beanstalk and Heroku
 - [ ] Integration test with newman 😉
 - [ ] Instructions on typescript debugging with VSCode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1162,6 +1162,15 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "celebrate": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-9.1.0.tgz",
+      "integrity": "sha512-QFVB7HazVEWUFbzyHkzw/f1Mq9Zg6uJ4MYcpl/Snpfa9wkUHn//HUlMvN0BWyZyc/X09HczNGnLBwSQFtMz1QQ==",
+      "requires": {
+        "escape-html": "1.0.3",
+        "joi": "14.x.x"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2823,6 +2832,11 @@
         }
       }
     },
+    "hoek": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3104,6 +3118,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -3761,6 +3783,16 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "requires": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
       }
     },
     "js-tokens": {
@@ -4894,8 +4926,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -5728,6 +5759,14 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "agenda": "^2.0.2",
     "argon2": "^0.21.0",
     "body-parser": "^1.18.2",
+    "celebrate": "^9.1.0",
     "cors": "^2.8.4",
     "dotenv": "^5.0.1",
     "errorhandler": "^1.5.0",

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -3,6 +3,7 @@ import { Container } from 'typedi';
 import AuthService from '../../services/auth';
 import { IUserInputDTO } from '../../interfaces/IUser';
 import middlewares from '../middlewares';
+import { celebrate, Joi } from 'celebrate';
 
 const route = Router();
 
@@ -10,18 +11,33 @@ export default (app) => {
 
   app.use('/auth', route);
 
-  route.post('/signup', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const authServiceInstance = Container.get(AuthService);
-      const { user, token } = await authServiceInstance.SignUp(req.body as IUserInputDTO);
-      return res.json({ user, token }).status(201);
-    } catch (e) {
-      console.log('🔥 error ', e);
-      return next(e);
-    }
+  route.post('/signup', 
+    celebrate({
+      body: Joi.object({
+        name: Joi.string().required(),
+        email: Joi.string().required(),
+        password: Joi.string().required(),
+      }),
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authServiceInstance = Container.get(AuthService);
+        const { user, token } = await authServiceInstance.SignUp(req.body as IUserInputDTO);
+        return res.json({ user, token }).status(201);
+      } catch (e) {
+        console.log('🔥 error ', e);
+        return next(e);
+      }
   });
 
-  route.post('/signin', async (req: Request, res: Response, next: NextFunction) => {
+  route.post('/signin', 
+    celebrate({
+      body: Joi.object({
+        email: Joi.string().required(),
+        password: Joi.string().required(),
+      }),
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { email, password } = req.body;
       const authServiceInstance = Container.get(AuthService);


### PR DESCRIPTION
# API Validation

  By using celebrate the req.body schema becomes clary defined at route level, so even frontend devs can read what an API endpoint expects without need to writting a documentation that can get outdated quickly.

  ```js
 route.post('/signup', 
  celebrate({
    body: Joi.object({
      name: Joi.string().required(),
      email: Joi.string().required(),
      password: Joi.string().required(),
    }),
  }),
  controller.signup)
 ```

  **Example error**

  ```json
 {
  "errors": {
    "message": "child \"email\" fails because [\"email\" is required]"
   }
 } 
 ```

 [Read more about celebrate here](https://github.com/arb/celebrate) and [the Joi validation API](https://github.com/hapijs/joi/blob/v15.0.1/API.md)