### PR TITLE
Correcting the response order for frontend take status

### DIFF
--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -25,7 +25,7 @@ export default (app: Router) => {
       try {
         const authServiceInstance = Container.get(AuthService);
         const { user, token } = await authServiceInstance.SignUp(req.body as IUserInputDTO);
-        return res.json({ user, token }).status(201);
+        return res.status(201).json({ user, token });
       } catch (e) {
         logger.error('🔥 error: %o', e);
         return next(e);


### PR DESCRIPTION
Correcting the response order for status> json because if the http status is 201 and in the order as it was it would return 200