### PR TITLE
Fixed import mailgun

### DIFF
--- a/src/loaders/dependencyInjector.ts
+++ b/src/loaders/dependencyInjector.ts
@@ -2,7 +2,7 @@ import { Container } from 'typedi';
 import LoggerInstance from './logger';
 import agendaFactory from './agenda';
 import config from '../config';
-import * as mailgun from 'mailgun-js';
+import mailgun from 'mailgun-js';
 
 export default ({ mongoConnection, models }: { mongoConnection; models: { name: string; model: any }[] }) => {
   try {


### PR DESCRIPTION
Because we have `"esModuleInterop": true` in _tsconfig.json_ so to import _mailgun-js_  we should use this: `import mailgun from 'mailgun-js';`
insteadof this: `import * as mailgun from 'mailgun-js';`
