### PR TITLE
Make contributions easier via automating the dev setup.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full:latest
+FROM gitpod/workspace-mongodb
+
+RUN bash -c ". .nvm/nvm.sh \
+    && nvm install 14.9.0 \
+    && nvm use 14.9.0 \
+    && nvm alias default 14.9.0"
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - name: Mongoose
+    init: npm install && gp sync-done install
+    command: |
+      cp .env.example .env
+      mkdir -p /workspace/data && mongod --dbpath /workspace/data
+
+  - name: Nodemon
+    init: gp sync-await install
+    command: npm start
+    openMode: split-right
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ npm run start
 ```
 It uses nodemon for livereloading :peace-fingers:
 
+## Online one-click setup
+
+You can use Gitpod for the one click online setup. With a single click it will launch a workspace and automatically:
+
+- clone the `bulletproof-nodejs` repo.
+- install the dependencies.
+- run `cp .env.example .env`.
+- run `npm run start`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 # API Validation
 
  By using celebrate the req.body schema becomes clary defined at route level, so even frontend devs can read what an API endpoint expects without need to writting a documentation that can get outdated quickly.


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `bulletproof-nodejs` repo.
- install the dependencies.
- run `cp .env.example .env`.
- start the database.
- run `npm start` to start nodemon.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/bulletproof-nodejs

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96427370-e6c2b580-1217-11eb-931a-28ca49a6d901.png)


