### PR TITLE
update @useoptic/express-middleware version to ^0.0.5 from ^0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "Santiago Quinteros",
   "license": "ISC",
   "dependencies": {
-    "@useoptic/express-middleware": "^0.0.3",
+    "@useoptic/express-middleware": "^0.0.5",
     "agenda": "^3.1.0",
     "agendash": "^2.1.1",
     "argon2": "^0.27.0",


### PR DESCRIPTION
I tried to build the project. But it returns error below.
https://github.com/opticdev/optic-node/issues/19

So I fixed it by updating its version to ^0.0.5 from ^0.0.3 and found it works.